### PR TITLE
Add missing inherits dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "errno": "0.1.4",
+    "inherits": "^2.0.1",
     "level-codec": "6.1.0",
     "ltgt": "2.1.2",
     "pull-stream": "2.21.0",


### PR DESCRIPTION
`inherits` is not declared as a dependency.

https://github.com/alexanderGugel/sublevel-pouchdb/blob/master/lib/read-stream.js#L9
